### PR TITLE
added client_secret config which is required when using HS256

### DIFF
--- a/src/Auth/Auth0Authenticate.php
+++ b/src/Auth/Auth0Authenticate.php
@@ -212,6 +212,8 @@ class Auth0Authenticate extends BaseAuthenticate
         try {
             $verifier = new JWTVerifier([
                 'supported_algs' => $config['supported_algs'],
+                'client_secret' => $config['auth0ClientSecret'],
+                'secret_base64_encoded' => false,
                 'valid_audiences' => [$config['auth0Audience']],
                 'authorized_iss' => ['https://' . $config['auth0Domain'] . '/'],
             ]);


### PR DESCRIPTION
When using HS256 you need to set the `client_secret` which is used in JWTVerifier.php dependency. Also auth0 Client Secret is not base64 encoded so need to set `secret_base64_encoded` to `false`.